### PR TITLE
fix type of np.stack

### DIFF
--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -169,7 +169,7 @@ class FeatureExtractor(metaclass=ABCMeta):
             else:
                 return result[0]
         elif all(item.shape == result[0].shape for item in result[1:]):
-            return np.stack(result, dim=0)
+            return np.stack(result, axis=0)
         else:
             return result
 


### PR DESCRIPTION
Is this a typo?
Accorind to numpy documents, the argument name of np.stack is **axis** not **dim**.
https://numpy.org/doc/stable/reference/generated/numpy.stack.html